### PR TITLE
Add Pester tests for WhatsApp cleaner

### DIFF
--- a/tests/Clean_data_whatsapp.Tests.ps1
+++ b/tests/Clean_data_whatsapp.Tests.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+$scriptPath = Join-Path $here '..' 'Clean_data_whatsapp.ps1'
+
+describe 'Clean_data_whatsapp.ps1' {
+    beforeAll {
+        $testDir = Join-Path $here 'tmp'
+        if (Test-Path $testDir) { Remove-Item $testDir -Recurse -Force }
+        New-Item -ItemType Directory -Path $testDir | Out-Null
+    }
+    afterAll {
+        if (Test-Path $testDir) { Remove-Item $testDir -Recurse -Force }
+    }
+
+    it 'parses lines with and without AM/PM correctly' {
+        $input = @"
+[1/12/23, 9:45:00 PM] John Doe: Hello!
+[1/12/23, 09:00:00] System: Server started
+Continuation line
+[1/12/23, 9:46:30 AM] Jane Smith: Morning!
+"@
+        $inputFile = Join-Path $testDir 'chat.txt'
+        $outputFile = Join-Path $testDir 'output.txt'
+        Set-Content -Path $inputFile -Value $input -Encoding UTF8
+        $responses = @($inputFile, $outputFile)
+        $index = 0
+        Mock -CommandName Read-Host -MockWith { $responses[$index++] }
+        . $scriptPath
+        $output = Get-Content $outputFile -Encoding UTF8
+        $expected = @(
+            "1/12/23`t9:45:00 PM`tJohn Doe`tHello!",
+            "1/12/23`t9:46:30 AM`tJane Smith`tMorning!"
+        )
+        $output | Should -BeExactly $expected
+    }
+}
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,17 @@
+# Running Tests
+
+This project uses [Pester](https://github.com/pester/Pester) for unit tests. Ensure you have PowerShell (v7 or newer) and the Pester module installed.
+
+From the repository root, run the tests with:
+
+```powershell
+Invoke-Pester
+```
+
+Or from a shell:
+
+```bash
+pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"
+```
+
+The command will discover tests in the `tests/` directory and report the results.


### PR DESCRIPTION
## Summary
- add a `tests` folder with Pester tests for `Clean_data_whatsapp.ps1`
- document how to run the tests in `tests/README.md`

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Output Detailed"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b5e97f088330b70596c9bdbab476