### PR TITLE
Add Excel split scripts with column autofit

### DIFF
--- a/SplitExcelByManager.bas
+++ b/SplitExcelByManager.bas
@@ -1,0 +1,31 @@
+Sub SplitExcelByManager()
+    Dim ws As Worksheet
+    Dim managerCol As Long
+    Dim lastRow As Long
+    Dim managers As Collection
+    Dim cell As Range
+    Dim newWb As Workbook
+    Dim manager As Variant
+
+    Set ws = ActiveSheet
+    managerCol = 1 'Assume manager is in column A
+    lastRow = ws.Cells(ws.Rows.Count, managerCol).End(xlUp).Row
+
+    Set managers = New Collection
+    On Error Resume Next
+    For Each cell In ws.Range(ws.Cells(2, managerCol), ws.Cells(lastRow, managerCol))
+        managers.Add cell.Value, CStr(cell.Value)
+    Next cell
+    On Error GoTo 0
+
+    For Each manager In managers
+        ws.Rows(1).AutoFilter Field:=managerCol, Criteria1:=manager
+        Set newWb = Workbooks.Add
+        ws.UsedRange.SpecialCells(xlCellTypeVisible).Copy newWb.Sheets(1).Range("A1")
+        newWb.Sheets(1).Columns.AutoFit
+        newWb.SaveAs manager & "_Report.xlsx"
+        newWb.Close False
+    Next manager
+
+    ws.AutoFilterMode = False
+End Sub

--- a/SplitExcelByManager.bas README.md
+++ b/SplitExcelByManager.bas README.md
@@ -1,0 +1,12 @@
+# Split Excel by Manager VBA Macro
+
+This VBA macro splits the active worksheet into separate workbooks based on the value in the **Manager** column (column A by default). For each unique manager, a new workbook is created containing only the rows for that manager.
+
+Each output workbook automatically adjusts column widths so that all data is visible.
+
+## Usage
+1. Open the workbook containing the data.
+2. Press `Alt+F11` to open the VBA editor and import `SplitExcelByManager.bas`.
+3. Run `SplitExcelByManager` from the editor.
+
+The macro will create a workbook for each manager in the same folder as the original file.

--- a/split_excel_by_manager.py
+++ b/split_excel_by_manager.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from openpyxl import load_workbook
+from openpyxl.utils import get_column_letter
+
+
+def split_excel_by_manager(path, manager_column='Manager'):
+    df = pd.read_excel(path)
+    for manager, group in df.groupby(manager_column):
+        out_path = f"{manager}_report.xlsx"
+        group.to_excel(out_path, index=False)
+        wb = load_workbook(out_path)
+        ws = wb.active
+        for idx, col in enumerate(ws.columns, 1):
+            max_len = 0
+            for cell in col:
+                if cell.value is not None:
+                    max_len = max(max_len, len(str(cell.value)))
+            ws.column_dimensions[get_column_letter(idx)].width = max_len + 2
+        wb.save(out_path)
+
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python split_excel_by_manager.py <excel_file> [manager_column]")
+    else:
+        col = sys.argv[2] if len(sys.argv) > 2 else 'Manager'
+        split_excel_by_manager(sys.argv[1], col)

--- a/split_excel_by_manager.py.README.md
+++ b/split_excel_by_manager.py.README.md
@@ -1,0 +1,9 @@
+# split_excel_by_manager.py
+
+This Python script reads an Excel file and saves a separate workbook for each unique value in the **Manager** column. It uses `pandas` for splitting and `openpyxl` to adjust the column widths of each output file automatically.
+
+## Usage
+```bash
+python split_excel_by_manager.py data.xlsx [ManagerColumn]
+```
+If `ManagerColumn` is omitted, it defaults to `Manager`.


### PR DESCRIPTION
## Summary
- add `SplitExcelByManager.bas` macro and README
- add `split_excel_by_manager.py` script and README
- both scripts now auto-adjust column widths in their output workbooks

## Testing
- `python -m py_compile split_excel_by_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b36092288330ad4d47a07b96b001