### PR TITLE
Improve SplitExcel macro filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,8 @@ secrets.json
 *.config
 *.key
 
+# Ignore directories created by split_excel_by_manager.py
+output/
+__pycache__/
+
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This repository contains a collection of PowerShell, MS Macros, and Bash scripts
 ## Scripts Index
 1. **Clean_data_Whatsapp.ps1**: A script for cleaning and processing text files, such as removing extra quotes, validating paths, and extracting data matching specific patterns.
 2. **WordResizeBorderImagesCleanlines.bas**: This program, written in VBA (Visual Basic for Applications), performs Resize and border Images:  and Cleans the Document.
-2. _[Placeholder for additional scripts]_: Add descriptions for other scripts as you add them.
+3. **split_excel_by_manager.py**: Split an Excel workbook into separate files for each manager in the `Manager` column.
+4. **SplitExcelByManager.bas**: VBA macro that creates a new workbook for every manager in the active sheet and lets you choose the save folder.
+5. _[Placeholder for additional scripts]_: Add descriptions for other scripts as you add them.
 
 ---
 

--- a/SplitExcelByManager.bas
+++ b/SplitExcelByManager.bas
@@ -1,0 +1,82 @@
+Option Explicit
+
+Sub SplitExcelByManager()
+    Dim src As Worksheet
+    Dim headerRow As Range
+    Dim managerHeader As String
+    Dim managerColIndex As Long
+    Dim lastRow As Long
+    Dim lastCol As Long
+    Dim dataRange As Range
+    Dim cell As Range
+    Dim managers As Object
+    Dim mgr As Variant
+    Dim savePath As String
+
+    Set src = ActiveSheet
+    Set headerRow = src.Rows(1)
+
+    managerHeader = InputBox("Enter the manager column header:", _
+                             "Manager Column", "Manager")
+
+    managerColIndex = 0
+    For Each cell In headerRow.Cells
+        If Trim(cell.Value) = managerHeader Then
+            managerColIndex = cell.Column
+            Exit For
+        End If
+        If cell.Value = "" Then Exit For
+    Next cell
+
+    If managerColIndex = 0 Then
+        MsgBox "Column '" & managerHeader & "' not found.", vbCritical
+        Exit Sub
+    End If
+
+    lastRow = src.Cells(src.Rows.Count, managerColIndex).End(xlUp).Row
+    lastCol = src.Cells(1, src.Columns.Count).End(xlToLeft).Column
+    Set dataRange = src.Range(src.Cells(1, 1), src.Cells(lastRow, lastCol))
+
+    Set managers = CreateObject("Scripting.Dictionary")
+    For Each cell In src.Range(src.Cells(2, managerColIndex), src.Cells(lastRow, managerColIndex))
+        If Trim(cell.Value) <> "" Then managers(cell.Value) = 1
+    Next cell
+
+    With Application.FileDialog(msoFileDialogFolderPicker)
+        .Title = "Select folder to save split workbooks"
+        .AllowMultiSelect = False
+        If .Show <> -1 Then
+            MsgBox "No folder selected. Operation canceled.", vbExclamation
+            Exit Sub
+        End If
+        savePath = .SelectedItems(1)
+    End With
+
+    For Each mgr In managers.Keys
+        src.AutoFilterMode = False
+        dataRange.AutoFilter Field:=managerColIndex, Criteria1:=mgr
+
+        Dim newWb As Workbook
+        Set newWb = Workbooks.Add(xlWBATWorksheet)
+        dataRange.SpecialCells(xlCellTypeVisible).Copy newWb.Sheets(1).Range("A1")
+
+        newWb.SaveAs Filename:=savePath & "\" & SanitizeFileName(CStr(mgr)) & ".xlsx", _
+                     FileFormat:=xlOpenXMLWorkbook
+        newWb.Close SaveChanges:=False
+    Next mgr
+
+    src.AutoFilterMode = False
+    MsgBox managers.Count & " file(s) saved to " & savePath, vbInformation
+End Sub
+
+Function SanitizeFileName(name As String) As String
+    Dim invalidChars As Variant
+    Dim ch As Variant
+    invalidChars = Array("\\", "/", ":", "*", "?", "\""", "<", ">", "|")
+    For Each ch In invalidChars
+        name = Replace(name, ch, "_")
+    Next ch
+    name = Trim(name)
+    If Len(name) = 0 Then name = "Unknown_Manager"
+    SanitizeFileName = name
+End Function

--- a/SplitExcelByManager.bas README.md
+++ b/SplitExcelByManager.bas README.md
@@ -1,0 +1,23 @@
+# Split Excel by Manager (VBA Macro)
+
+## Overview
+`SplitExcelByManager.bas` is a VBA macro for Microsoft Excel. It splits the active worksheet into separate workbooks based on the manager names found in a specified column (default `Manager`). Each new workbook contains the rows for one manager.
+
+## Usage
+1. Open your source workbook in Excel.
+2. Press `Alt + F11` and import `SplitExcelByManager.bas`.
+3. Run `SplitExcelByManager` from the macros list.
+   - When prompted, enter the column header containing manager names.
+  - Choose the destination folder when the folder picker appears.
+   - The macro now filters using the full data range to avoid AutoFilter errors.
+
+## Example
+Running the macro with the default `Manager` column creates files like `Alice.xlsx` and `Bob.xlsx` in the folder you selected.
+
+## Task List for SplitExcelByManager.bas
+- [x] Allow user to choose a different save location
+- [ ] Show progress while creating files
+- [ ] Handle protected or filtered worksheets gracefully
+
+## License
+This script is released under the [GNU General Public License v3.0](LICENSE).

--- a/split_excel_by_manager.py
+++ b/split_excel_by_manager.py
@@ -1,0 +1,42 @@
+import os
+import re
+import pandas as pd
+import argparse
+
+
+def sanitize_filename(name: str) -> str:
+    """Return a filesystem-safe filename from a string."""
+    sanitized = re.sub(r'[\\/*?:"<>|]', '_', str(name))
+    sanitized = sanitized.strip()
+    return sanitized or "Unknown_Manager"
+
+
+def split_excel_by_manager(input_path: str, output_dir: str, manager_column: str = "Manager") -> None:
+    """Split an Excel sheet into multiple files based on the manager column."""
+    df = pd.read_excel(input_path)
+    if manager_column not in df.columns:
+        raise ValueError(f"Column '{manager_column}' not found in input file")
+
+    grouped = df.groupby(manager_column)
+    os.makedirs(output_dir, exist_ok=True)
+
+    for manager, group in grouped:
+        manager_safe = sanitize_filename(manager)
+        output_file = os.path.join(output_dir, f"{manager_safe}.xlsx")
+        group.to_excel(output_file, index=False)
+
+    print(f"Saved {len(grouped)} file(s) to '{output_dir}'.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Split an Excel file by the Manager column.")
+    parser.add_argument("input_excel", help="Path to the source Excel file")
+    parser.add_argument("-o", "--output-dir", default="output", help="Directory for the split files")
+    parser.add_argument("-c", "--column", default="Manager", help="Column name that contains manager names")
+    args = parser.parse_args()
+
+    split_excel_by_manager(args.input_excel, args.output_dir, args.column)
+
+
+if __name__ == "__main__":
+    main()

--- a/split_excel_by_manager.py README.md
+++ b/split_excel_by_manager.py README.md
@@ -1,0 +1,30 @@
+# Split Excel by Manager
+
+## Overview
+`split_excel_by_manager.py` is a Python utility that divides a single Excel workbook into multiple files, one for each manager listed in a column (default `Manager`). Each resulting file contains only the rows associated with that manager.
+
+## Usage
+1. Ensure you have Python and `pandas` installed:
+   ```bash
+   pip install pandas
+   ```
+2. Run the script specifying the source Excel file:
+   ```bash
+   python split_excel_by_manager.py path/to/input.xlsx -o output_directory
+   ```
+   - `-o` or `--output-dir` sets the directory where individual files will be saved. The directory is created if it does not exist.
+   - `-c` or `--column` lets you specify a different column name if your manager field is not called `Manager`.
+
+## Example
+```bash
+python split_excel_by_manager.py staff_list.xlsx -o splits
+```
+This command produces one Excel file per unique manager name, stored in the `splits` directory.
+
+## Task List for split_excel_by_manager.py
+- [ ] Add option for CSV output
+- [ ] Add unit tests
+- [ ] Support Google Sheets input
+
+## License
+This script is released under the [GNU General Public License v3.0](LICENSE).


### PR DESCRIPTION
## Summary
- fix `SplitExcelByManager` AutoFilter range to avoid `1004` errors
- note the new filtering behavior in the macro README

## Testing
- `python -m py_compile split_excel_by_manager.py`
- `python split_excel_by_manager.py --help` (after installing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_6841a52da6948330b958dc450873b68f