### PR TITLE
Fix message extraction in WhatsApp cleaner

### DIFF
--- a/Clean_data_whatsapp.ps1
+++ b/Clean_data_whatsapp.ps1
@@ -37,9 +37,10 @@ Get-Content $inputFile -Encoding UTF8 | ForEach-Object {
         
         # Extract Column C (Name) by capturing text between ] and :
         $columnC = ($_ -replace ".*\] (.*?):.*", '$1').Trim()  # Trim leading/trailing spaces
-        
-        # Extract Column D (Message) by capturing text after the colon
-        $columnD = ($_ -replace ".*: (.*)", '$1').Trim()  # Trim leading/trailing spaces
+
+        # Extract Column D (Message) by removing the timestamp and name prefix
+        # This avoids truncating messages that themselves contain colons
+        $columnD = ($_ -replace "^\[[^\]]+\] [^:]+: ?", '').Trim()
 
         # Concatenate and store the result for output (CSV-like format with tab separation)
         $fixedLines += "$date`t$time`t$columnC`t$columnD"

--- a/Clean_data_whatsapp.ps1 README.md
+++ b/Clean_data_whatsapp.ps1 README.md
@@ -20,6 +20,8 @@ While optimized for WhatsApp chats, this script can also be used for other gener
 
 4. **Tab-Separated Output:**
    - Saves cleaned data in a tab-separated format for easy import into Excel or other tools.
+5. **Colon Handling:**
+   - Correctly parses messages even when the text itself contains colons.
 
 ---
 


### PR DESCRIPTION
## Summary
- prevent message truncation when text contains colons
- document colon handling in the script README

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_6841a4dfad908330bfe7bee430272838